### PR TITLE
Fetch automatically latest active task definition.

### DIFF
--- a/ecs_tool/cli.py
+++ b/ecs_tool/cli.py
@@ -13,8 +13,9 @@ from ecs_tool.ecs import (
 )
 from ecs_tool.exceptions import (
     NoResultsException,
-    TasksCannotBeRunException,
+    TaskDefinitionInactiveException,
     WaiterException,
+    NoTaskDefinitionFoundException,
 )
 from ecs_tool.tables import ServicesTable, TasksTable, TaskDefinitionsTable
 
@@ -154,7 +155,11 @@ def run_task(
             wait_max_attempts,
             command,
         )
-    except (TasksCannotBeRunException, WaiterException) as e:
+    except (
+        TaskDefinitionInactiveException,
+        WaiterException,
+        NoTaskDefinitionFoundException,
+    ) as e:
         click.secho(str(e), fg="red")
         sys.exit(1)
 

--- a/ecs_tool/exceptions.py
+++ b/ecs_tool/exceptions.py
@@ -8,9 +8,15 @@ class WaiterException(EcsToolException):
     """
 
 
-class TasksCannotBeRunException(EcsToolException):
+class TaskDefinitionInactiveException(EcsToolException):
     """
-    Exception used when task cannot be run.
+    Task definition is inactive, we can't run task.
+    """
+
+
+class NoTaskDefinitionFoundException(EcsToolException):
+    """
+    No task definition found.
     """
 
 


### PR DESCRIPTION
- When running `ecs run-task` you don’t have to provide number of task definition anymore, it will automatically select latest active
- Some changes in exception naming etc.